### PR TITLE
stub and spy methods

### DIFF
--- a/duck/__init__.py
+++ b/duck/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Luke Sneeringer
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
+from duck.api import spy
 from duck.api import stub
 from duck.compat import mock
 from duck.mocks import Mock
@@ -17,6 +18,7 @@ __all__ = (
     'Mock',
     'sentinel',
     'Spy',
+    'spy',
     'Stub',
     'stub',
 )

--- a/duck/api.py
+++ b/duck/api.py
@@ -33,4 +33,41 @@ def stub(target, attribute=None, create=False, spec=None,
             this is :class:`duck.mocks.Stub`.
         kwargs (dict): Any additional keyword arguments are passed to the
             callable.
+
+    Returns:
+        unittest.mock._patch: A patch object provided by mock.
     """
+    # Determine the appropriate spec for the mock.
+    # By default, this is autospec=True, unless a spec is provided or
+    # explicitly turned off.
+    if spec is None:
+        kwargs['autospec'] = True
+    elif spec is not False:
+        kwargs['spec_set'] = spec
+
+    # Place the `create` and `new_callable` arguments into **kwargs.
+    kwargs['create'] = create
+    kwargs['new_callable'] = new_callable
+
+    # Return the appropriate mock function.
+    if attribute is not None:
+        return mock.patch.object(target, attribute, **kwargs)
+    return mock.patch(target, **kwargs)
+
+
+def spy(target, attribute):
+    """Replace the given target with a spy object.
+
+    The substitute object is a :class:`duck.Spy` object, which is a mock
+    that will nonetheless route the actual calls to the original object.
+
+    Args:
+        target (Union[class, module]): This is expected to be a class or
+            module, and it is provided to :meth:`mock.patch.object`.
+        attribute (str): The attribute to be replaced.
+
+    Returns:
+        unittest.mock._patch: A patch object provided by mock.
+    """
+    spy_ = mocks.Spy(wraps=getattr(target, attribute), name=attribute)
+    return mock.patch.object(target, attribute, new_callable=spy_)

--- a/duck/api.py
+++ b/duck/api.py
@@ -56,7 +56,10 @@ def stub(target, attribute=None, create=False, spec=None,
     # have to duplicate some mock logic here since we are using our own
     # callable.
     if spec is None:
-        stub.mock_add_spec(patcher.get_original()[0], spec_set=True)
+        stub.mock_add_spec(
+            mock.create_autospec(patcher.get_original()[0]),
+            spec_set=True,
+        )
     elif spec is not False:
         stub.mock_add_spec(spec, spec_set=True)
     else:
@@ -80,5 +83,5 @@ def spy(target, attribute):
     Returns:
         unittest.mock._patch: A patch object provided by mock.
     """
-    spy_ = mocks.Spy(wraps=getattr(target, attribute), name=attribute)
-    return mock.patch.object(target, attribute, new_callable=spy_)
+    spy_ = mocks.Spy(wraps=getattr(target, attribute))
+    return mock.patch.object(target, attribute, new=spy_)

--- a/duck/mocks.py
+++ b/duck/mocks.py
@@ -47,7 +47,14 @@ class Mock(mock.MagicMock):
     """
     def __init__(self, name=None, spec=(), side_effect=None,
                  return_value=mock.DEFAULT, wraps=None, **kwargs):
-        pass
+        return super(Mock, self).__init__(
+            name=name,
+            return_value=return_value,
+            side_effect=side_effect,
+            spec_set=spec,
+            wraps=wraps,
+            **kwargs
+        )
 
 
 class Stub(Mock):
@@ -55,7 +62,19 @@ class Stub(Mock):
 
 
 class Spy(Stub):
-    pass
+    """A Spy object, which wraps another object but passes calls on to it.
+
+    Args:
+        wraps (Callable): The callable to be spied on. Attribute access on the
+            mock will return a Mock object that wraps the corresponding
+            attribute of the wrapped object (so attempting to access an
+            attribute that does not exist will raise :exc:`AttributeError`).
+    """
+    def __init__(self, wraps):
+        return super(Spy, self).__init__(
+            name=wraps.__name__,
+            wraps=wraps,
+        )
 
 
 __all__ = (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,8 @@
 # Copyright 2017 Luke Sneeringer
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-import time
+import json
+import logging
 
 import pytest
 
@@ -9,17 +10,42 @@ import duck
 
 
 def test_stub_context_manager():
-    with duck.stub(time, 'sleep') as sleep:
-        time.sleep(42)
-        sleep.assert_called_once_with(42)
+    with duck.stub(json, 'dumps') as dumps:
+        json.dumps({'foo': 42})
+        dumps.assert_called_once_with({'foo': 42})
         with pytest.raises(AttributeError):
-            sleep.bar
+            dumps.bar
 
 
 def test_stub_no_spec():
-    with duck.stub(time, 'sleep', spec=False) as sleep:
-        time.sleep(42)
-        sleep.assert_called_once_with(42)
+    with duck.stub(json, 'dumps', spec=False) as dumps:
+        json.dumps({'foo': 42})
+        dumps.assert_called_once_with({'foo': 42})
 
         # Since spec=False was sent, this should be acceptable.
-        assert isinstance(sleep.bar, duck.Stub)
+        assert isinstance(dumps.bar, duck.Stub)
+
+
+def test_stub_explicit_spec():
+    with duck.stub(logging, 'Logger', spec=['info']) as mock_logger:
+        mock_logger.return_value = mock_logger
+        logger = logging.Logger()
+        logger.info('foo')
+        with pytest.raises(AttributeError):
+            logger.error('bar')
+        mock_logger.info.assert_called_once_with('foo')
+
+
+def test_stub_string_only():
+    with duck.stub('json.dumps') as dumps:
+        json.dumps({'foo': 42})
+        dumps.assert_called_once_with({'foo': 42})
+
+
+def test_spy():
+    with duck.spy(json, 'dumps') as dumps:
+        # The actual json.dumps method will raise TypeError if it gets
+        # unrecognized objects.
+        with pytest.raises(TypeError):
+            json.dumps({'foo': duck.sentinel.NO_SERIALIZATION})
+        dumps.assert_called_once_with({'foo': duck.sentinel.NO_SERIALIZATION})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,25 @@
 # Copyright 2017 Luke Sneeringer
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-from duck import api
+import time
+
+import pytest
+
+import duck
 
 
-def test_stub():
-    # FIXME: Implement this test when the actual code is implemented.
-    assert api.stub('foo') is None
+def test_stub_context_manager():
+    with duck.stub(time, 'sleep') as sleep:
+        time.sleep(42)
+        sleep.assert_called_once_with(42)
+        with pytest.raises(AttributeError):
+            sleep.bar
+
+
+def test_stub_no_spec():
+    with duck.stub(time, 'sleep', spec=False) as sleep:
+        time.sleep(42)
+        sleep.assert_called_once_with(42)
+
+        # Since spec=False was sent, this should be acceptable.
+        assert isinstance(sleep.bar, duck.Stub)


### PR DESCRIPTION
The `stub` and `spy` methods ended up being shockingly simple.

This should *not* be merged until I get unit testing set up.