### PR TITLE
Dev ornithology - Comparison classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ target/
 .venv
 venv/
 ENV/
+
+# IDEs
+.idea
+.idea/*

--- a/duck/__init__.py
+++ b/duck/__init__.py
@@ -21,6 +21,6 @@ __all__ = (
     'Spy',
     'Stub',
     'stub',
-    'ANY'
-    'Instance'
+    'ANY',
+    'Instance',
 )

--- a/duck/__init__.py
+++ b/duck/__init__.py
@@ -21,4 +21,6 @@ __all__ = (
     'Spy',
     'Stub',
     'stub',
+    'ANY'
+    'Instance'
 )

--- a/duck/__init__.py
+++ b/duck/__init__.py
@@ -7,6 +7,8 @@ from duck.mocks import MagicMock
 from duck.mocks import Mock
 from duck.mocks import Spy
 from duck.mocks import Stub
+from duck.ornithology import ANY
+from duck.ornithology import Instance
 
 # Expose certain items in `mock` in our namespace.
 DEFAULT = mock.DEFAULT

--- a/duck/ornithology.py
+++ b/duck/ornithology.py
@@ -15,18 +15,19 @@ class _Instance(object):
     True if and only if the other comparison object is an
     instance of the provided class (as defined by isinstance).
     """
+    def __init__(self, _class):
+        self._class = _class
 
     def __eq__(self, other):
-        return isinstance(self, other)
+        return isinstance(other, self._class)
 
     def __ne__(self, other):
-        return -isinstance(self, other)
+        return not isinstance(other, self._class)
 
     def __repr__(self):
         return '<Instance>'
 
-Instance = _Instance()
-
+Instance = _Instance
 
 __all__ = (
     'ANY',

--- a/duck/ornithology.py
+++ b/duck/ornithology.py
@@ -1,0 +1,34 @@
+# Copyright 2017 Luke Sneeringer
+# Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+from duck.compat import mock
+
+# Contains the comparisons preserved from mock for use in asserts.
+
+# Alias of mock.ANY
+ANY = mock.ANY
+
+
+class _Instance(object):
+    """
+    Instances of Instance have an .__eq__ method that returns
+    True if and only if the other comparison object is an
+    instance of the provided class (as defined by isinstance).
+    """
+
+    def __eq__(self, other):
+        return isinstance(self, other)
+
+    def __ne__(self, other):
+        return -isinstance(self, other)
+
+    def __repr__(self):
+        return '<Instance>'
+
+Instance = _Instance
+
+
+__all__ = (
+    'ANY',
+    'Instance'
+)

--- a/duck/ornithology.py
+++ b/duck/ornithology.py
@@ -25,7 +25,7 @@ class _Instance(object):
     def __repr__(self):
         return '<Instance>'
 
-Instance = _Instance
+Instance = _Instance()
 
 
 __all__ = (

--- a/duck/ornithology.py
+++ b/duck/ornithology.py
@@ -27,7 +27,9 @@ class _Instance(object):
     def __repr__(self):
         return '<Instance>'
 
+
 Instance = _Instance
+
 
 __all__ = (
     'ANY',

--- a/duck/ornithology.py
+++ b/duck/ornithology.py
@@ -22,7 +22,7 @@ class Instance(object):
         return isinstance(other, self._class)
 
     def __ne__(self, other):
-        return not isinstance(other, self._class)
+        return not self._class == other
 
     def __repr__(self):
         return '<Instance>'
@@ -30,5 +30,5 @@ class Instance(object):
 
 __all__ = (
     'ANY',
-    'Instance'
+    'Instance',
 )

--- a/duck/ornithology.py
+++ b/duck/ornithology.py
@@ -22,10 +22,10 @@ class Instance(object):
         return isinstance(other, self._class)
 
     def __ne__(self, other):
-        return not self._class == other
+        return not self == other
 
     def __repr__(self):
-        return '<Instance>'
+        return '<Instance: {}>'.format(self._class.__name__)
 
 
 __all__ = (

--- a/duck/ornithology.py
+++ b/duck/ornithology.py
@@ -10,7 +10,8 @@ ANY = mock.ANY
 
 
 class Instance(object):
-    """
+    """A class that checks equality based on type.
+
     Instances of Instance have an .__eq__ method that returns
     True if and only if the other comparison object is an
     instance of the provided class (as defined by isinstance).
@@ -25,7 +26,7 @@ class Instance(object):
         return not self == other
 
     def __repr__(self):
-        return '<Instance: {}>'.format(self._class.__name__)
+        return '<Instance: {0}>'.format(self._class.__name__)
 
 
 __all__ = (

--- a/duck/ornithology.py
+++ b/duck/ornithology.py
@@ -9,7 +9,7 @@ from duck.compat import mock
 ANY = mock.ANY
 
 
-class _Instance(object):
+class Instance(object):
     """
     Instances of Instance have an .__eq__ method that returns
     True if and only if the other comparison object is an
@@ -26,9 +26,6 @@ class _Instance(object):
 
     def __repr__(self):
         return '<Instance>'
-
-
-Instance = _Instance
 
 
 __all__ = (

--- a/tests/test_ornithology.py
+++ b/tests/test_ornithology.py
@@ -41,14 +41,14 @@ def test_ornithology_science():
     a specific incompatability in python 3.4
     :return:
     """
-    mockint = duck.Mock(spec=int)
+#    mockint = duck.Mock(spec=int)
 #    mockfloat = duck.Mock(spec=float)
 #    assert mockint == Instance(int)
 #    assert mockfloat != Instance(int)
     assert 42 == Instance(int)
     assert 2.718 != Instance(int)
-    assert mockint == ANY
-    assert not mockint != ANY
+#    assert mockint == ANY
+#    assert not mockint != ANY
     assert "foo" == ANY
     assert not "foobar" != ANY
     assert repr(Instance(int)) == '<Instance: int>'

--- a/tests/test_ornithology.py
+++ b/tests/test_ornithology.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Luke Sneeringer
+# Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+from duck.ornithology import Instance
+from duck.ornithology import ANY
+from duck.compat import mock
+import duck
+
+
+def test_ornithology():
+    mockint = duck.Mock(spec=int)
+    mockfloat = duck.Mock(spec=float)
+    assert mockint == Instance(int)
+    assert mockfloat != Instance(int)
+    assert mockint == ANY
+    assert not mockint != ANY
+
+
+def test_ornithology_compat():
+    mockint = mock.Mock(spec=int)
+    mockfloat = mock.Mock(spec=float)
+    assert mockint == Instance(int)
+    assert mockfloat != Instance(int)
+    assert mockint == ANY
+    assert not mockint != ANY

--- a/tests/test_ornithology.py
+++ b/tests/test_ornithology.py
@@ -2,9 +2,9 @@
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
 import duck
-from duck.ornithology import Instance
-from duck.ornithology import ANY
 from duck.compat import mock
+from duck.ornithology import ANY
+from duck.ornithology import Instance
 
 
 def test_ornithology():

--- a/tests/test_ornithology.py
+++ b/tests/test_ornithology.py
@@ -1,10 +1,10 @@
 # Copyright 2017 Luke Sneeringer
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
+import duck
 from duck.ornithology import Instance
 from duck.ornithology import ANY
 from duck.compat import mock
-import duck
 
 
 def test_ornithology():

--- a/tests/test_ornithology.py
+++ b/tests/test_ornithology.py
@@ -12,16 +12,43 @@ def test_ornithology():
     mockfloat = duck.Mock(spec=float)
     assert Instance(int) == mockint
     assert Instance(int) != mockfloat
+    assert Instance(int) == 42
+    assert Instance(int) != 2.718
     assert ANY == mockint
     assert not ANY != mockint
+    assert ANY == "foo"
+    assert not ANY != "foobar"
     assert repr(Instance(int)) == '<Instance: int>'
 
 
 def test_ornithology_compat():
     mockint = mock.Mock(spec=int)
     mockfloat = mock.Mock(spec=float)
-    assert Instance(int) == mockint
+    assert mockint == Instance(int)
     assert Instance(int) != mockfloat
+    assert Instance(int) == 42
+    assert Instance(int) != 2.718
     assert ANY == mockint
     assert not ANY != mockint
-    assert repr(Instance(int)) == "<Instance: int>"
+    assert ANY == "foo"
+    assert not ANY != "foobar"
+    assert repr(Instance(int)) == '<Instance: int>'
+
+
+def test_ornithology_science():
+    """
+    Reverse ordered test cases to find out if there's
+    a specific incompatability in python 3.4
+    :return:
+    """
+    mockint = duck.Mock(spec=int)
+#    mockfloat = duck.Mock(spec=float)
+#    assert mockint == Instance(int)
+#    assert mockfloat != Instance(int)
+    assert 42 == Instance(int)
+    assert 2.718 != Instance(int)
+    assert mockint == ANY
+    assert not mockint != ANY
+    assert "foo" == ANY
+    assert not "foobar" != ANY
+    assert repr(Instance(int)) == '<Instance: int>'

--- a/tests/test_ornithology.py
+++ b/tests/test_ornithology.py
@@ -14,6 +14,7 @@ def test_ornithology():
     assert Instance(int) != mockfloat
     assert ANY == mockint
     assert not ANY != mockint
+    assert repr(Instance(int)) == '<Instance: int>'
 
 
 def test_ornithology_compat():
@@ -23,3 +24,4 @@ def test_ornithology_compat():
     assert Instance(int) != mockfloat
     assert ANY == mockint
     assert not ANY != mockint
+    assert repr(Instance(int)) == "<Instance: int>"

--- a/tests/test_ornithology.py
+++ b/tests/test_ornithology.py
@@ -10,16 +10,16 @@ from duck.compat import mock
 def test_ornithology():
     mockint = duck.Mock(spec=int)
     mockfloat = duck.Mock(spec=float)
-    assert mockint == Instance(int)
-    assert mockfloat != Instance(int)
-    assert mockint == ANY
-    assert not mockint != ANY
+    assert Instance(int) == mockint
+    assert Instance(int) != mockfloat
+    assert ANY == mockint
+    assert not ANY != mockint
 
 
 def test_ornithology_compat():
     mockint = mock.Mock(spec=int)
     mockfloat = mock.Mock(spec=float)
-    assert mockint == Instance(int)
-    assert mockfloat != Instance(int)
-    assert mockint == ANY
-    assert not mockint != ANY
+    assert Instance(int) == mockint
+    assert Instance(int) != mockfloat
+    assert ANY == mockint
+    assert not ANY != mockint


### PR DESCRIPTION
Borrowing from the style of Mock. Implemented Instance and the alias for Mock.ANY

One note I'm seeing in the Mock source is
```
def _is_instance_mock(obj): 
    # can't use isinstance on Mock objects because they override __class__
    # The base class for all mocks is NonCallableMock
```

so I'm not entirely convinced this will work